### PR TITLE
Register original class names and aliases for backward compatibility.

### DIFF
--- a/midgard.c
+++ b/midgard.c
@@ -378,9 +378,11 @@ PHP_MINIT_FUNCTION(midgard2)
 
 	/* Register midgard_metadata class */
 	static zend_class_entry midgard_metadata_class_entry;
-	INIT_CLASS_ENTRY(midgard_metadata_class_entry, "midgard_metadata", NULL);
+	INIT_CLASS_ENTRY(midgard_metadata_class_entry, "MidgardMetadata", NULL);
 	midgard_metadata_class = zend_register_internal_class(&midgard_metadata_class_entry TSRMLS_CC);
 	midgard_metadata_class->create_object = php_midgard_gobject_new;
+
+	zend_register_class_alias("midgard_metadata", midgard_metadata_class);
 
 #define MGD_PHP_REGISTER_CONSTANT(name) \
 	REGISTER_LONG_CONSTANT(#name, name, CONST_CS | CONST_PERSISTENT)

--- a/php_midgard_blob.c
+++ b/php_midgard_blob.c
@@ -227,11 +227,13 @@ PHP_MINIT_FUNCTION(midgard2_blob)
 	};
 
 	static zend_class_entry php_midgard_blob_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_blob_class_entry, "midgard_blob", blob_methods);
+	INIT_CLASS_ENTRY(php_midgard_blob_class_entry, "MidgardBlob", blob_methods);
 
 	php_midgard_blob_class = zend_register_internal_class(&php_midgard_blob_class_entry TSRMLS_CC);
 	php_midgard_blob_class->create_object = php_midgard_gobject_new;
 	php_midgard_blob_class->doc_comment = strdup("Wrapper around midgard_attachment object, which provides high-level API for working with larget binary entities");
+
+	zend_register_class_alias("midgard_blob", php_midgard_blob_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_collector.c
+++ b/php_midgard_collector.c
@@ -522,12 +522,15 @@ PHP_MINIT_FUNCTION(midgard2_collector)
 	};
 
 	static zend_class_entry php_midgard_collector_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_collector_class_entry, "midgard_collector", collector_methods);
+	INIT_CLASS_ENTRY(php_midgard_collector_class_entry, "MidgardCollector", collector_methods);
 
 	/* FIXME, this inheritance should be automatic once we switch to namespaces */
-	php_midgard_collector_class =  zend_register_internal_class_ex (&php_midgard_collector_class_entry, NULL, "midgard_query_builder" TSRMLS_CC);
+	zend_class_entry *qbce = php_midgard_get_class_ptr_by_name("MidgardQueryBuilder");
+	php_midgard_collector_class =  zend_register_internal_class_ex (&php_midgard_collector_class_entry, qbce, "MidgardQueryBuilder" TSRMLS_CC);
 	php_midgard_collector_class->create_object = php_midgard_gobject_new;
 	php_midgard_collector_class->doc_comment = strdup("Optimized database query tool, that doesn't return objects");
+
+	zend_register_class_alias("midgard_collector", php_midgard_collector_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_config.c
+++ b/php_midgard_config.c
@@ -193,11 +193,13 @@ PHP_MINIT_FUNCTION(midgard2_config)
 	};
 
 	static zend_class_entry php_midgard_config_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_config_class_entry, "midgard_config", midgard_config_methods);
+	INIT_CLASS_ENTRY(php_midgard_config_class_entry, "MidgardConfig", midgard_config_methods);
 
 	php_midgard_config_class = zend_register_internal_class(&php_midgard_config_class_entry TSRMLS_CC);
 	php_midgard_config_class->create_object = php_midgard_gobject_new;
 	php_midgard_config_class->doc_comment = strdup("Represents Midgard unified configuration file");
+	
+	zend_register_class_alias("midgard_config", php_midgard_config_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_connection.c
+++ b/php_midgard_connection.c
@@ -557,8 +557,7 @@ static PHP_METHOD (midgard_connection, get_workspace)
 		return;
 
 	const char *g_class_name = G_OBJECT_TYPE_NAME (workspace);
-	const char *ws_cname = g_class_name_to_php_class_name (g_class_name);
-	zend_class_entry *ce = zend_fetch_class ((char *) ws_cname, strlen (ws_cname), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
+	zend_class_entry *ce = zend_fetch_class ((char *) g_class_name, strlen (g_class_name), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 	php_midgard_gobject_new_with_gobject (return_value, ce, g_object_ref (G_OBJECT (workspace)), TRUE TSRMLS_CC);
 }
@@ -632,7 +631,7 @@ PHP_MINIT_FUNCTION(midgard2_connection)
 
 	static zend_class_entry php_midgard_connection_class_entry;
 
-	INIT_CLASS_ENTRY(php_midgard_connection_class_entry, "midgard_connection", connection_methods);
+	INIT_CLASS_ENTRY(php_midgard_connection_class_entry, "MidgardConnection", connection_methods);
 	php_midgard_connection_class = zend_register_internal_class(&php_midgard_connection_class_entry TSRMLS_CC);
 
 	php_midgard_connection_class->create_object = php_midgard_gobject_new;
@@ -641,6 +640,8 @@ PHP_MINIT_FUNCTION(midgard2_connection)
 	php_midgard_connection_class->doc_comment = strdup("midgard_connection class represents connection to underlying data-source and is responsible for holding and setting environmental variables (like error, authenticated user, debug level, etc.)");
 
 	zend_declare_property_null(php_midgard_connection_class, "instance", sizeof("instance")-1, ZEND_ACC_PRIVATE|ZEND_ACC_STATIC TSRMLS_CC);
+
+	zend_register_class_alias("midgard_connection", php_midgard_connection_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_dbus.c
+++ b/php_midgard_dbus.c
@@ -119,11 +119,13 @@ PHP_MINIT_FUNCTION(midgard2_dbus)
 
 	static zend_class_entry php_midgard_dbus_class_entry;
 
-	INIT_CLASS_ENTRY(php_midgard_dbus_class_entry, "midgard_dbus", midgard_dbus_methods);
+	INIT_CLASS_ENTRY(php_midgard_dbus_class_entry, "MidgardDbus", midgard_dbus_methods);
 
 	php_midgard_dbus_class = zend_register_internal_class(&php_midgard_dbus_class_entry TSRMLS_CC);
 	php_midgard_dbus_class->create_object = php_midgard_gobject_new;
 	php_midgard_dbus_class->doc_comment = strdup("Sender of DBUS messages");
+
+	zend_register_class_alias("midgard_dbus", php_midgard_dbus_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_gobject.h
+++ b/php_midgard_gobject.h
@@ -65,7 +65,6 @@ void php_midgard_gobject_unset_property(zval *object, zval *member TSRMLS_DC);
 void php_midgard_gobject_connect(INTERNAL_FUNCTION_PARAMETERS);
 void php_midgard_object_class_connect_default(INTERNAL_FUNCTION_PARAMETERS);
 
-const char* g_class_name_to_php_class_name(const gchar *g_class_name);
 const gchar* php_class_name_to_g_class_name(const char *php_class_name);
 
 #endif /* PHP_MIDGARD_GOBJECT_GENERIC  */

--- a/php_midgard_gobject_generic.c
+++ b/php_midgard_gobject_generic.c
@@ -243,10 +243,8 @@ zend_bool php_midgard_gvalue2zval(const GValue *gvalue, zval *zvalue TSRMLS_DC)
 					if (!gclass_name)
 						return FALSE;
 
-					const char *php_class_name = g_class_name_to_php_class_name(gclass_name);
-
 					g_object_ref(gobject_property);
-					php_midgard_gobject_init(zvalue, php_class_name, gobject_property, TRUE TSRMLS_CC);
+					php_midgard_gobject_init(zvalue, gclass_name, gobject_property, TRUE TSRMLS_CC);
 
 					if (MGDG(midgard_memory_debug)) {
 						printf("php_midgard_gvalue2zval: [%p] refcount=%d, gobj=%p, glib refcount=%d\n", zvalue, Z_REFCOUNT_P(zvalue), gobject_property, gobject_property->ref_count);
@@ -1063,100 +1061,11 @@ CLEAN_AND_RETURN_NULL:
 	return NULL;
 }
 
-const char* g_class_name_to_php_class_name(const char *g_class_name)
-{
-	if (strcmp(g_class_name, "MidgardMetadata") == 0) {
-		return "midgard_metadata";
-	} else if (strcmp(g_class_name, "MidgardDBObject") == 0) {
-		return "midgard_dbobject";
-	} else if (strcmp(g_class_name, "MidgardObject") == 0) {
-		return "midgard_object";
-	} else if (strcmp(g_class_name, "MidgardConnection") == 0) {
-		return "midgard_connection";
-	} else if (strcmp(g_class_name, "MidgardQueryStorage") == 0) {
-		return "midgard_query_storage";
-	} else if (strcmp(g_class_name, "MidgardQueryProperty") == 0) {
-		return "midgard_query_property";
-	} else if (strcmp(g_class_name, "MidgardQueryValue") == 0) {
-		return "midgard_query_value";
-	} else if (strcmp(g_class_name, "MidgardQueryConstraintGroup") == 0) {
-		return "midgard_query_constraint_group";
-	} else if (strcmp(g_class_name, "MidgardQueryConstraint") == 0) {
-		return "midgard_query_constraint";
-	} else if (strcmp(g_class_name, "MidgardUser") == 0) {
-		return "midgard_user";
-	} else if (strcmp(g_class_name, "MidgardView") == 0) {
-		return "midgard_view";
-	} else if (strcmp(g_class_name, "MidgardDBObject") == 0) {
-		return "midgard_dbobject";
-	} else if (strcmp(g_class_name, "MidgardConfig") == 0) {
-		return "midgard_config";
-	} else if (strcmp(g_class_name, "MidgardDbus") == 0) {
-		return "midgard_dbus";
-	} else if (strcmp(g_class_name, "MidgardReflectionProperty") == 0) {
-		return "midgard_reflection_property";
-	} else if (strcmp(g_class_name, "MidgardCollector") == 0) {
-		return "midgard_collector";
-	} else if (strcmp(g_class_name, "MidgardWorkspaceStorage") == 0) {
-		return "midgard_workspace_storage";
-	} else if (strcmp(g_class_name, "MidgardWorkspace") == 0) {
-		return "midgard_workspace";
-	} else if (strcmp(g_class_name, "MidgardWorkspaceContext") == 0) {
-		return "midgard_workspace_context";
-	} else if (strcmp(g_class_name, "MidgardWorkspaceManager") == 0) {
-		return "midgard_workspace_manager";
-	} else if (strcmp(g_class_name, "MidgardRepligard") == 0) {
-		return "midgard_repligard";
-	}
-
-	return g_class_name;
-}
-
 const gchar* php_class_name_to_g_class_name(const char *php_class_name)
 {
-	if (strcmp(php_class_name, "midgard_metadata") == 0) {
-		return "MidgardMetadata";
-	} else if (strcmp(php_class_name, "midgard_dbobject") == 0) {
-		return "MidgardDBObject";
-	} else if (strcmp(php_class_name, "midgard_object") == 0) {
-		return "MidgardObject";
-	} else if (strcmp(php_class_name, "midgard_connection") == 0) {
-		return "MidgardConnection";
-	} else if (strcmp(php_class_name, "midgard_query_storage") == 0) {
-		return "MidgardQueryStorage";
-	} else if (strcmp(php_class_name, "midgard_query_property") == 0) {
-		return "MidgardQueryProperty";
-	} else if (strcmp(php_class_name, "midgard_query_value") == 0) {
-		return "MidgardQueryValue";
-	} else if (strcmp(php_class_name, "midgard_query_constraint_group") == 0) {
-		return "MidgardQueryConstraintGroup";
-	} else if (strcmp(php_class_name, "midgard_query_constraint") == 0) {
-		return "MidgardQueryConstraint";
-	} else if (strcmp(php_class_name, "midgard_user") == 0) {
-		return "MidgardUser";
-	} else if (strcmp(php_class_name, "midgard_view") == 0) {
-		return "MidgardView";
-	} else if (strcmp(php_class_name, "midgard_dbobject") == 0) {
-		return "MidgardDBObject";
-	} else if (strcmp(php_class_name, "midgard_config") == 0) {
-		return "MidgardConfig";
-	} else if (strcmp(php_class_name, "midgard_dbus") == 0) {
-		return "MidgardDbus";
-	} else if (strcmp(php_class_name, "midgard_reflection_property") == 0) {
-		return "MidgardReflectionProperty";
-	} else if (strcmp(php_class_name, "midgard_collector") == 0) {
-		return "MidgardCollector";
-	} else if (strcmp(php_class_name, "midgard_workspace_storage") == 0) {
-		return "MidgardWorkspaceStorage";
-	} else if (strcmp(php_class_name, "midgard_workspace") == 0) {
-		return "MidgardStorage";
-	} else if (strcmp(php_class_name, "midgard_workspace_context") == 0) {
-		return "MidgardWorkspaceContext";
-	} else if (strcmp(php_class_name, "midgard_workspace_manager") == 0) {
-		return "MidgardWorkspaceManager";
-	} else if (strcmp(php_class_name, "midgard_repligard") == 0) {
-		return "MidgardRepligard";
-	}
+	zend_class_entry *ce = php_midgard_get_class_ptr_by_name(php_class_name TSRMLS_CC);
+	if (ce)
+		return ce->name;
 
 	return php_class_name;
 }

--- a/php_midgard_key_config.c
+++ b/php_midgard_key_config.c
@@ -256,13 +256,15 @@ PHP_MINIT_FUNCTION(midgard2_key_config)
 
 	static zend_class_entry php_midgard_key_config_class_entry;
 
-	INIT_CLASS_ENTRY(php_midgard_key_config_class_entry, "midgard_key_config", midgard_key_config_methods);
+	INIT_CLASS_ENTRY(php_midgard_key_config_class_entry, "MidgardKeyConfig", midgard_key_config_methods);
 
 	php_midgard_key_config_class = zend_register_internal_class(&php_midgard_key_config_class_entry TSRMLS_CC);
 
 	php_midgard_key_config_class->ce_flags = ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 	php_midgard_key_config_class->doc_comment = strdup("Abstract class for key-value (ini like) configurations");
 	php_midgard_key_config_class->create_object = php_midgard_gobject_new;
+	
+	zend_register_class_alias("midgard_key_config", php_midgard_key_config_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_key_config_context.c
+++ b/php_midgard_key_config_context.c
@@ -86,13 +86,15 @@ PHP_MINIT_FUNCTION(midgard2_key_config_context)
 	};
 
 	static zend_class_entry php_midgard_key_config_context_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_key_config_context_class_entry, "midgard_key_config_context", midgard_key_config_context_methods);
+	INIT_CLASS_ENTRY(php_midgard_key_config_context_class_entry, "MidgardKeyConfigContext", midgard_key_config_context_methods);
 
 	php_midgard_key_config_context_class = zend_register_internal_class(&php_midgard_key_config_context_class_entry TSRMLS_CC);
 
 	php_midgard_key_config_context_class->ce_flags = ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 	php_midgard_key_config_context_class->doc_comment = strdup("Abstract class for key-value (ini like) configuration contexts");
 	php_midgard_key_config_context_class->create_object = php_midgard_gobject_new;
+
+	zend_register_class_alias("midgard_key_config_context", php_midgard_key_config_context_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_key_config_file.c
+++ b/php_midgard_key_config_file.c
@@ -66,12 +66,14 @@ PHP_MINIT_FUNCTION(midgard2_key_config_file)
 	};
 
 	static zend_class_entry php_midgard_key_config_file_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_key_config_file_class_entry, "midgard_key_config_file", midgard_key_config_file_methods);
+	INIT_CLASS_ENTRY(php_midgard_key_config_file_class_entry, "MidgardKeyConfigFile", midgard_key_config_file_methods);
 
 	php_midgard_key_config_file_class = zend_register_internal_class_ex(&php_midgard_key_config_file_class_entry, NULL, "midgard_key_config" TSRMLS_CC);
 
 	php_midgard_key_config_file_class->doc_comment = strdup("File based key-value (ini like) configurations");
 	php_midgard_key_config_file_class->create_object = php_midgard_gobject_new;
+
+	zend_register_class_alias("midgard_key_config_file", php_midgard_key_config_file_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_object.c
+++ b/php_midgard_object.c
@@ -1302,7 +1302,7 @@ __register_php_class(const gchar *class_name, zend_class_entry *parent TSRMLS_DC
 	/* Register all derived classes */
 	GType *derived = g_type_children(g_type_from_name(class_name), &n_types);
 	for (i = 0; i < n_types; i++) {
-		const gchar *typename = g_class_name_to_php_class_name(g_type_name(derived[i]));
+		const gchar *typename = g_type_name(derived[i]);
 		__register_php_class(typename, mgdclass_ptr);
 		__add_method_comments(typename);
 	}
@@ -1313,21 +1313,24 @@ PHP_MINIT_FUNCTION(midgard2_object)
 {
 	/* Register midgard_dbobject class */
 	static zend_class_entry php_midgard_dbobject_ce;
-	INIT_CLASS_ENTRY(php_midgard_dbobject_ce, "midgard_dbobject", NULL);
+	INIT_CLASS_ENTRY(php_midgard_dbobject_ce, "MidgardDBObject", NULL);
 
 	php_midgard_dbobject_class = zend_register_internal_class(&php_midgard_dbobject_ce TSRMLS_CC);
+	zend_register_class_alias("midgard_dbobject", php_midgard_dbobject_class);
 
 	/* Register midgard_object class */
 	static zend_class_entry php_midgard_object_ce;
-	INIT_CLASS_ENTRY(php_midgard_object_ce, "midgard_object", NULL);
+	INIT_CLASS_ENTRY(php_midgard_object_ce, "MidgardObject", NULL);
 
-	php_midgard_object_class = zend_register_internal_class_ex(&php_midgard_object_ce, php_midgard_dbobject_class, "midgard_dbobject" TSRMLS_CC);
+	php_midgard_object_class = zend_register_internal_class_ex(&php_midgard_object_ce, php_midgard_dbobject_class, "MidgardDBObject" TSRMLS_CC);
+	zend_register_class_alias ("midgard_object", php_midgard_object_class);
+
 
 	guint n_types, i;
 	GType *all_types = g_type_children(MIDGARD_TYPE_OBJECT, &n_types);
 
 	for (i = 0; i < n_types; i++) {
-		const gchar *typename = g_class_name_to_php_class_name(g_type_name(all_types[i]));
+		const gchar *typename = g_type_name(all_types[i]);
 		__register_php_class(typename, php_midgard_object_class TSRMLS_CC);
 		__add_method_comments(typename);
 	}
@@ -1399,7 +1402,7 @@ PHP_MINIT_FUNCTION(midgard2_base_abstract)
 	GType *all_types = g_type_children(MIDGARD_TYPE_BASE_ABSTRACT, &n_types);
 
 	for (i = 0; i < n_types; i++) {
-		const gchar *typename = g_class_name_to_php_class_name(g_type_name(all_types[i]));
+		const gchar *typename = g_type_name(all_types[i]);
 		__register_abstract_php_classes(typename, php_midgard_base_abstract_class TSRMLS_CC);
 	}
 

--- a/php_midgard_query_constraints.c
+++ b/php_midgard_query_constraints.c
@@ -345,13 +345,14 @@ PHP_MINIT_FUNCTION(midgard2_query_constraints)
 	};
 
 	static zend_class_entry php_midgard_query_constraint_simple_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_constraint_simple_class_entry, "midgard_query_constraint_simple", midgard_query_constraint_simple_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_constraint_simple_class_entry, "MidgardQueryConstraintSimple", midgard_query_constraint_simple_methods);
 
 	php_midgard_query_constraint_simple_class = zend_register_internal_class(&php_midgard_query_constraint_simple_class_entry TSRMLS_CC);
 	php_midgard_query_constraint_simple_class->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 	php_midgard_query_constraint_simple_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_constraint_simple_class->doc_comment = strdup("Base class for holding constraint information for midgard_query");
 
+	zend_register_class_alias("midgard_query_constraint_simple", php_midgard_query_constraint_simple_class);
 
 	static function_entry midgard_query_constraint_methods[] = {
 		PHP_ME(midgard_query_constraint, __construct,  arginfo_midgard_query_constraint___construct,  ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -365,12 +366,13 @@ PHP_MINIT_FUNCTION(midgard2_query_constraints)
 	};
 
 	static zend_class_entry php_midgard_query_constraint_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_constraint_class_entry, "midgard_query_constraint", midgard_query_constraint_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_constraint_class_entry, "MidgardQueryConstraint", midgard_query_constraint_methods);
 
 	php_midgard_query_constraint_class = zend_register_internal_class_ex(&php_midgard_query_constraint_class_entry, php_midgard_query_constraint_simple_class, "midgard_query_constraint_simple" TSRMLS_CC);
 	php_midgard_query_constraint_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_constraint_class->doc_comment = strdup("Class for holding simple constraint in midgard_query");
 
+	zend_register_class_alias("midgard_query_constraint", php_midgard_query_constraint_class);
 
 	static function_entry midgard_query_constraint_group_methods[] = {
 		PHP_ME(midgard_query_constraint_group, __construct,          arginfo_midgard_query_constraint_group___construct,          ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -381,11 +383,13 @@ PHP_MINIT_FUNCTION(midgard2_query_constraints)
 	};
 
 	static zend_class_entry php_midgard_query_constraint_group_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_constraint_group_class_entry, "midgard_query_constraint_group", midgard_query_constraint_group_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_constraint_group_class_entry, "MidgardQueryConstraintGroup", midgard_query_constraint_group_methods);
 
 	php_midgard_query_constraint_group_class = zend_register_internal_class_ex(&php_midgard_query_constraint_group_class_entry, php_midgard_query_constraint_simple_class, "midgard_query_constraint_group" TSRMLS_CC);
 	php_midgard_query_constraint_group_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_constraint_group_class->doc_comment = strdup("Class for holding group of constraints in midgard_query");
+
+	zend_register_class_alias("midgard_query_constraint_group", php_midgard_query_constraint_group_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_query_executors.c
+++ b/php_midgard_query_executors.c
@@ -301,13 +301,14 @@ PHP_MINIT_FUNCTION(midgard2_query_executors)
 	};
 
 	static zend_class_entry php_midgard_query_executor_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_executor_class_entry, "midgard_query_executor", midgard_query_executor_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_executor_class_entry, "MidgardQueryExecutor", midgard_query_executor_methods);
 
 	php_midgard_query_executor_class = zend_register_internal_class(&php_midgard_query_executor_class_entry TSRMLS_CC);
 	php_midgard_query_executor_class->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 	php_midgard_query_executor_class->create_object = php_midgard_gobject_new;
-	php_midgard_query_executor_class->doc_comment = strdup("Base class for midgard_query query executors");
+	php_midgard_query_executor_class->doc_comment = strdup("Base, abstract class for queries executions");
 
+	zend_register_class_alias("midgard_query_executor", php_midgard_query_executor_class);
 
 	static function_entry midgard_query_select_methods[] = {
 		PHP_ME(midgard_query_select, __construct,      arginfo_midgard_query_select___construct,      ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -319,12 +320,13 @@ PHP_MINIT_FUNCTION(midgard2_query_executors)
 	};
 
 	static zend_class_entry php_midgard_query_select_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_select_class_entry, "midgard_query_select", midgard_query_select_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_select_class_entry, "MidgardQuerySelect", midgard_query_select_methods);
 
 	php_midgard_query_select_class = zend_register_internal_class_ex(&php_midgard_query_select_class_entry, php_midgard_query_executor_class, "midgard_query_executor" TSRMLS_CC);
 	php_midgard_query_select_class->create_object = php_midgard_gobject_new;
-	php_midgard_query_select_class->doc_comment = strdup("midgard_query Select query executor");
+	php_midgard_query_select_class->doc_comment = strdup("SQL SELECT queries generator and executor");
 
+	zend_register_class_alias("midgard_query_select", php_midgard_query_select_class);
 
 	return SUCCESS;
 }
@@ -346,9 +348,8 @@ static void php_midgard_array_from_unknown_objects(MidgardDBObject **objects, gu
 		GObject *object = G_OBJECT(objects[i]);
 		GType object_type = G_OBJECT_TYPE(object);
 		const gchar *g_class_name = g_type_name(object_type);
-		const char *php_class_name = g_class_name_to_php_class_name(g_class_name);
 
-		zend_class_entry *ce = zend_fetch_class((char *)php_class_name, strlen(php_class_name), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);;
+		zend_class_entry *ce = zend_fetch_class((char *)g_class_name, strlen(g_class_name), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 		zval *zobject;
 		MAKE_STD_ZVAL(zobject);

--- a/php_midgard_query_holders.c
+++ b/php_midgard_query_holders.c
@@ -138,13 +138,14 @@ PHP_MINIT_FUNCTION(midgard2_query_holders)
 	};
 
 	static zend_class_entry php_midgard_query_holder_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_holder_class_entry, "midgard_query_holder", midgard_query_holder_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_holder_class_entry, "MidgardQueryHolder", midgard_query_holder_methods);
 
 	php_midgard_query_holder_class = zend_register_internal_class(&php_midgard_query_holder_class_entry TSRMLS_CC);
 	php_midgard_query_holder_class->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 	php_midgard_query_holder_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_holder_class->doc_comment = strdup("Base class for holding data-atom in midgard_query");
 
+	zend_register_class_alias("midgard_query_holder", php_midgard_query_holder_class);
 
 	static function_entry midgard_query_property_methods[] = {
 		PHP_ME(midgard_query_property, __construct, arginfo_midgard_query_property___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -152,12 +153,13 @@ PHP_MINIT_FUNCTION(midgard2_query_holders)
 	};
 
 	static zend_class_entry php_midgard_query_property_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_property_class_entry, "midgard_query_property", midgard_query_property_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_property_class_entry, "MidgardQueryProperty", midgard_query_property_methods);
 
 	php_midgard_query_property_class = zend_register_internal_class_ex(&php_midgard_query_property_class_entry, php_midgard_query_holder_class, "midgard_query_holder" TSRMLS_CC);
 	php_midgard_query_property_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_property_class->doc_comment = strdup("Class for holding object-properties");
 
+	zend_register_class_alias("midgard_query_property", php_midgard_query_property_class);
 
 	static function_entry midgard_query_value_methods[] = {
 		PHP_ME(midgard_query_value, __construct, arginfo_midgard_query_value___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -165,11 +167,13 @@ PHP_MINIT_FUNCTION(midgard2_query_holders)
 	};
 
 	static zend_class_entry php_midgard_query_value_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_value_class_entry, "midgard_query_value", midgard_query_value_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_value_class_entry, "MidgardQueryValue", midgard_query_value_methods);
 
 	php_midgard_query_value_class = zend_register_internal_class_ex(&php_midgard_query_value_class_entry, php_midgard_query_holder_class, "midgard_query_holder" TSRMLS_CC);
 	php_midgard_query_value_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_value_class->doc_comment = strdup("Class for holding literal data");
+
+	zend_register_class_alias("midgard_query_value", php_midgard_query_value_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_query_storage.c
+++ b/php_midgard_query_storage.c
@@ -55,11 +55,13 @@ PHP_MINIT_FUNCTION(midgard2_query_storage)
 	};
 
 	static zend_class_entry php_midgard_query_storage_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_query_storage_class_entry, "midgard_query_storage", midgard_query_storage_methods);
+	INIT_CLASS_ENTRY(php_midgard_query_storage_class_entry, "MidgardQueryStorage", midgard_query_storage_methods);
 
 	php_midgard_query_storage_class = zend_register_internal_class(&php_midgard_query_storage_class_entry TSRMLS_CC);
 	php_midgard_query_storage_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_storage_class->doc_comment = strdup("Wraps DBObject for use with midgard_query_* classes");
+
+	zend_register_class_alias("midgard_query_storage", php_midgard_query_storage_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_reflector_object.c
+++ b/php_midgard_reflector_object.c
@@ -491,5 +491,7 @@ PHP_MINIT_FUNCTION(midgard2_reflector_object)
 	php_midgard_reflector_object_class = zend_register_internal_class(&php_midgard_reflector_object_class_entry TSRMLS_CC);
 	php_midgard_reflector_object_class->doc_comment = strdup("Collection of static methods which provide reflection for MgdSchema classes");
 
+	zend_register_class_alias("midgard_reflector_object", php_midgard_reflector_object_class);
+
 	return SUCCESS;
 }

--- a/php_midgard_reflector_property.c
+++ b/php_midgard_reflector_property.c
@@ -382,5 +382,7 @@ PHP_MINIT_FUNCTION(midgard2_reflector_property)
 	php_midgard_reflector_property_class = zend_register_internal_class(&reflector_property_class_entry TSRMLS_CC);
 	php_midgard_reflector_property_class->create_object = php_midgard_gobject_new;
 
+	zend_register_class_alias("midgard_reflector_property", php_midgard_reflector_property_class);
+
 	return SUCCESS;
 }

--- a/php_midgard_replicator.c
+++ b/php_midgard_replicator.c
@@ -263,10 +263,12 @@ PHP_MINIT_FUNCTION(midgard2_replicator)
 	};
 
 	static zend_class_entry php_midgard_replicator_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_replicator_class_entry, "midgard_replicator", replicator_methods);
+	INIT_CLASS_ENTRY(php_midgard_replicator_class_entry, "MidgardReplicator", replicator_methods);
 
 	php_midgard_replicator_class = zend_register_internal_class(&php_midgard_replicator_class_entry TSRMLS_CC);
 	php_midgard_replicator_class->doc_comment = strdup("Collection of static methods for serializing, unserializing data to XML; importing and exporting it");
+
+	zend_register_class_alias("midgard_replicator", php_midgard_replicator_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_storage.c
+++ b/php_midgard_storage.c
@@ -123,11 +123,13 @@ PHP_MINIT_FUNCTION(midgard2_storage)
 	};
 
 	static zend_class_entry php_midgard_storage_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_storage_class_entry, "midgard_storage", midgard_storage_methods);
+	INIT_CLASS_ENTRY(php_midgard_storage_class_entry, "MidgardStorage", midgard_storage_methods);
 
 	php_midgard_storage_class = zend_register_internal_class(&php_midgard_storage_class_entry TSRMLS_CC);
 	php_midgard_storage_class->create_object = NULL;
 	php_midgard_storage_class->doc_comment = strdup("Collection of static methods for managing underlying data storage");
+
+	zend_register_class_alias("midgard_storage", php_midgard_storage_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_timestamp.c
+++ b/php_midgard_timestamp.c
@@ -288,7 +288,7 @@ PHP_MINIT_FUNCTION(midgard2_datetime)
 	};
 
 	static zend_class_entry php_midgard_datetime_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_datetime_class_entry, "midgard_datetime", midgard_datetime_methods);
+	INIT_CLASS_ENTRY(php_midgard_datetime_class_entry, "MidgardDatetime", midgard_datetime_methods);
 
 	php_midgard_datetime_class = zend_register_internal_class_ex(&php_midgard_datetime_class_entry, zend_datetime_class_ptr, "DateTime" TSRMLS_CC);
 	php_midgard_datetime_class->doc_comment = strdup("Midgard's version of DateTime class");
@@ -296,6 +296,8 @@ PHP_MINIT_FUNCTION(midgard2_datetime)
 	/* Register properties */
 	zend_declare_property_string(php_midgard_datetime_class, "object",   sizeof("object")-1,   "", ZEND_ACC_PRIVATE TSRMLS_CC);
 	zend_declare_property_string(php_midgard_datetime_class, "property", sizeof("property")-1, "", ZEND_ACC_PRIVATE TSRMLS_CC);
+
+	zend_register_class_alias("midgard_datetime", php_midgard_datetime_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_transaction.c
+++ b/php_midgard_transaction.c
@@ -165,7 +165,7 @@ PHP_MINIT_FUNCTION(midgard2_transaction)
 	};
 
 	static zend_class_entry php_midgard_transaction_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_transaction_class_entry, "midgard_transaction", transaction_methods);
+	INIT_CLASS_ENTRY(php_midgard_transaction_class_entry, "MidgardTransaction", transaction_methods);
 
 	php_midgard_transaction_class = zend_register_internal_class(&php_midgard_transaction_class_entry TSRMLS_CC);
 
@@ -174,6 +174,8 @@ PHP_MINIT_FUNCTION(midgard2_transaction)
 	php_midgard_transaction_class->serialize = NULL; /* FIXME, set (un)serialize for some explicit error if needed */
 	php_midgard_transaction_class->unserialize = NULL;
 	php_midgard_transaction_class->doc_comment = strdup("Transaction manager");
+
+	zend_register_class_alias("midgard_transaction", php_midgard_transaction_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_user.c
+++ b/php_midgard_user.c
@@ -322,7 +322,7 @@ PHP_MINIT_FUNCTION(midgard2_user)
 	};
 
 	static zend_class_entry php_midgard_user_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_user_class_entry, "midgard_user", midgard_user_methods);
+	INIT_CLASS_ENTRY(php_midgard_user_class_entry, "MidgardUser", midgard_user_methods);
 
 	php_midgard_user_class = zend_register_internal_class_ex(&php_midgard_user_class_entry, NULL, "midgard_dbobject" TSRMLS_CC);
 
@@ -331,6 +331,8 @@ PHP_MINIT_FUNCTION(midgard2_user)
 	php_midgard_user_class->doc_comment = strdup("Midgard's Authentication API");
 	php_midgard_user_class->serialize = php_midgard_serialize_dbobject_hook;
 	php_midgard_user_class->unserialize = php_midgard_unserialize_dbobject_hook;
+
+	zend_register_class_alias("midgard_user", php_midgard_user_class);
 
 	return SUCCESS;
 }

--- a/php_midgard_view.c
+++ b/php_midgard_view.c
@@ -123,9 +123,9 @@ PHP_MINIT_FUNCTION(midgard2_view)
 {
 	/* Register midgard_view class */
 	static zend_class_entry php_midgard_view_ce;
-	INIT_CLASS_ENTRY(php_midgard_view_ce, "midgard_view", NULL);
+	INIT_CLASS_ENTRY(php_midgard_view_ce, "MidgardView", NULL);
 
-	php_midgard_view_class = zend_register_internal_class_ex(&php_midgard_view_ce, php_midgard_dbobject_class, "midgard_view" TSRMLS_CC);
+	php_midgard_view_class = zend_register_internal_class_ex(&php_midgard_view_ce, php_midgard_dbobject_class, "MidgardDBObject" TSRMLS_CC);
 
 	guint n_types, i;
 	GType *all_types = g_type_children(MIDGARD_TYPE_VIEW, &n_types);
@@ -134,6 +134,8 @@ PHP_MINIT_FUNCTION(midgard2_view)
 		const gchar *typename = g_type_name(all_types[i]);
 		__register_view_php_classes(typename, php_midgard_view_class TSRMLS_CC);
 	}
+
+	zend_register_class_alias("midgard_view", php_midgard_view_class);
 
 	g_free(all_types);
 

--- a/php_midgard_workspace_storage.c
+++ b/php_midgard_workspace_storage.c
@@ -83,8 +83,7 @@ static PHP_METHOD(midgard_workspace_storage, list_children)
 		return;
 
 	const char *g_class_name = G_OBJECT_TYPE_NAME(children[0]);
-	const char *ws_cname = g_class_name_to_php_class_name(g_class_name);
-	zend_class_entry *ce = zend_fetch_class((char *) ws_cname, strlen(ws_cname), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
+	zend_class_entry *ce = zend_fetch_class((char *) g_class_name, strlen(g_class_name), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 	int i;
 	for (i = 0; i < n_objects; i++) {
@@ -207,8 +206,7 @@ static PHP_METHOD(midgard_workspace_manager, __construct)
 {
 	zval *z_mgd = NULL;
 	const gchar *g_class_name = g_type_name(MIDGARD_TYPE_CONNECTION);
-	const char *php_class_name = g_class_name_to_php_class_name(g_class_name);
-	zend_class_entry *ce = zend_fetch_class((char *)php_class_name, strlen(php_class_name), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
+	zend_class_entry *ce = zend_fetch_class((char *)g_class_name, strlen(g_class_name), ZEND_FETCH_CLASS_AUTO TSRMLS_CC);
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &z_mgd, ce) == FAILURE) {
 		return;
@@ -432,13 +430,14 @@ PHP_MINIT_FUNCTION(midgard2_workspaces)
 	};
 
 	static zend_class_entry php_midgard_workspace_storage_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_workspace_storage_class_entry, "midgard_workspace_storage", midgard_workspace_storage_methods);
+	INIT_CLASS_ENTRY(php_midgard_workspace_storage_class_entry, "MidgardWorkspaceStorage", midgard_workspace_storage_methods);
 
 	php_midgard_workspace_storage_class = zend_register_internal_class(&php_midgard_workspace_storage_class_entry TSRMLS_CC);
 	php_midgard_workspace_storage_class->ce_flags |= ZEND_ACC_EXPLICIT_ABSTRACT_CLASS;
 	php_midgard_workspace_storage_class->create_object = php_midgard_gobject_new;
 	php_midgard_workspace_storage_class->doc_comment = strdup("Base class for workspaces");
 
+	zend_register_class_alias("midgard_workspace_storage", php_midgard_workspace_storage_class);
 
 	static function_entry midgard_workspace_methods[] = {
 		PHP_ME(midgard_workspace, __construct, arginfo_midgard_workspace___construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -447,12 +446,13 @@ PHP_MINIT_FUNCTION(midgard2_workspaces)
 	};
 
 	static zend_class_entry php_midgard_workspace_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_workspace_class_entry, "midgard_workspace", midgard_workspace_methods);
+	INIT_CLASS_ENTRY(php_midgard_workspace_class_entry, "MidgardWorkspace", midgard_workspace_methods);
 
 	php_midgard_workspace_class = zend_register_internal_class_ex(&php_midgard_workspace_class_entry, php_midgard_workspace_storage_class, "midgard_workspace_storage" TSRMLS_CC);
 	php_midgard_workspace_class->create_object = php_midgard_gobject_new;
 	php_midgard_workspace_class->doc_comment = strdup("Represents single workspace");
 
+	zend_register_class_alias("midgard_workspace", php_midgard_workspace_class);
 
 	static function_entry midgard_workspace_context_methods[] = {
 		PHP_ME(midgard_workspace_context, __construct,   arginfo_midgard_workspace_context___construct,   ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -461,12 +461,13 @@ PHP_MINIT_FUNCTION(midgard2_workspaces)
 	};
 
 	static zend_class_entry php_midgard_workspace_context_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_workspace_context_class_entry, "midgard_workspace_context", midgard_workspace_context_methods);
+	INIT_CLASS_ENTRY(php_midgard_workspace_context_class_entry, "MidgardWorkspaceContext", midgard_workspace_context_methods);
 
 	php_midgard_workspace_context_class = zend_register_internal_class_ex(&php_midgard_workspace_context_class_entry, php_midgard_workspace_storage_class, "midgard_workspace_storage" TSRMLS_CC);
 	php_midgard_workspace_context_class->create_object = php_midgard_gobject_new;
 	php_midgard_workspace_context_class->doc_comment = strdup("Represents workspaces' tree");
 
+	zend_register_class_alias("midgard_workspace_context", php_midgard_workspace_context_class);
 
 	static function_entry midgard_workspace_manager_methods[] = {
 		PHP_ME(midgard_workspace_manager, __construct,           arginfo_midgard_workspace_manager___construct,           ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -481,11 +482,13 @@ PHP_MINIT_FUNCTION(midgard2_workspaces)
 	};
 
 	static zend_class_entry php_midgard_workspace_manager_class_entry;
-	INIT_CLASS_ENTRY(php_midgard_workspace_manager_class_entry, "midgard_workspace_manager", midgard_workspace_manager_methods);
+	INIT_CLASS_ENTRY(php_midgard_workspace_manager_class_entry, "MidgardWorkspaceManager", midgard_workspace_manager_methods);
 
 	php_midgard_workspace_manager = zend_register_internal_class(&php_midgard_workspace_manager_class_entry TSRMLS_CC);
 	php_midgard_workspace_manager->create_object = php_midgard_gobject_new;
 	php_midgard_workspace_manager->doc_comment = strdup("Workspaces' manager");
+
+	zend_register_class_alias("midgard_workspace_manager", php_midgard_workspace_manager);
 
 	return SUCCESS;
 }

--- a/query_builder.c
+++ b/query_builder.c
@@ -388,10 +388,12 @@ PHP_MINIT_FUNCTION(midgard2_query_builder)
 
 	static zend_class_entry query_builder_class_entry;
 
-	INIT_CLASS_ENTRY(query_builder_class_entry, "midgard_query_builder", query_builder_methods);
+	INIT_CLASS_ENTRY(query_builder_class_entry, "MidgardQueryBuilder", query_builder_methods);
 	php_midgard_query_builder_class = zend_register_internal_class(&query_builder_class_entry TSRMLS_CC);
 	php_midgard_query_builder_class->create_object = php_midgard_gobject_new;
 	php_midgard_query_builder_class->doc_comment = strdup("API for building complex data-queries");
+
+	zend_register_class_alias("midgard_query_builder", php_midgard_query_builder_class);
 
 	return SUCCESS;
 }


### PR DESCRIPTION
Follow zend_class_entry name as valid class name required for core
operations.
Fixes gh-34
Fixes gh-37
